### PR TITLE
Remove synthetic methods instrumentation

### DIFF
--- a/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
@@ -25,8 +25,8 @@ class AnnotationThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
 
     private final Set<String> notNullAnnotations;
 
-    AnnotationThrowOnNullMethodVisitor(@Nullable final MethodVisitor methodVisitor, @NotNull final Type[] argumentTypes, @NotNull final Type returnType, final int access, @NotNull final String methodName, @NotNull final String className, @NotNull final Set<String> notNullAnnotations) {
-        super(Opcodes.ASM5, methodVisitor, argumentTypes, returnType, access, methodName, className, false);
+    AnnotationThrowOnNullMethodVisitor(@Nullable final MethodVisitor methodVisitor, @NotNull final Type[] argumentTypes, @NotNull final Type returnType, final int access, @NotNull final String methodName, @NotNull final String className, @NotNull final Set<String> notNullAnnotations, boolean isAnonymous) {
+        super(Opcodes.ASM5, methodVisitor, argumentTypes, returnType, access, methodName, className, false, isAnonymous);
         this.notNullAnnotations = notNullAnnotations;
     }
 

--- a/src/main/java/com/intellij/compiler/notNullVerification/ImplicitThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ImplicitThrowOnNullMethodVisitor.java
@@ -26,28 +26,11 @@ import java.util.Set;
 class ImplicitThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
 
     private final Set<String> nullableAnnotations;
-    private final boolean isAnonymousClass;
 
     ImplicitThrowOnNullMethodVisitor(@Nullable final MethodVisitor methodVisitor, @NotNull final Type[] argumentTypes, @NotNull final Type returnType, final int access, @NotNull final String methodName, @NotNull final String className, @NotNull final Set<String> nullableAnnotations, final boolean isAnonymousClass) {
-        super(Opcodes.ASM5, methodVisitor, argumentTypes, returnType, access, methodName, className, true);
+        super(Opcodes.ASM5, methodVisitor, argumentTypes, returnType, access, methodName, className, true, isAnonymousClass);
         this.nullableAnnotations = nullableAnnotations;
-        this.isAnonymousClass = isAnonymousClass;
-        if (!isSynthetic() && !isAnonymousClassConstructor()) {
-            addImplicitNotNulls();
-        }
-    }
-
-    private boolean isAnonymousClassConstructor() {
-        return isAnonymousClass && isConstructor();
-    }
-
-    private boolean isConstructor() {
-        return "<init>".equals(this.methodName);
-    }
-
-    @Contract(pure = true)
-    private boolean isSynthetic() {
-        return (this.access & Opcodes.ACC_SYNTHETIC) == Opcodes.ACC_SYNTHETIC;
+        addImplicitNotNulls();
     }
 
     private void addImplicitNotNulls() {
@@ -82,7 +65,7 @@ class ImplicitThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
     }
 
     private boolean setNullable(final int parameter) {
-        return notNullParams.remove((Integer)parameter);
+        return notNullParams.remove((Integer) parameter);
     }
 
     /**

--- a/src/main/java/com/intellij/compiler/notNullVerification/NotNullInstrumenterClassVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/NotNullInstrumenterClassVisitor.java
@@ -81,7 +81,7 @@ public class NotNullInstrumenterClassVisitor extends ClassVisitor {
         if (classAnnotatedImplicit || configuration.isImplicitInstrumentation(toClassName(className))) {
             visitor = new ImplicitThrowOnNullMethodVisitor(methodVisitor, argumentTypes, returnType, access, name, className, nullable, isAnonymous);
         } else {
-            visitor = new AnnotationThrowOnNullMethodVisitor(methodVisitor, argumentTypes, returnType, access, name, className, notnull);
+            visitor = new AnnotationThrowOnNullMethodVisitor(methodVisitor, argumentTypes, returnType, access, name, className, notnull, isAnonymous);
         }
         methodVisitors.add(visitor);
         return visitor;

--- a/src/main/java/com/intellij/compiler/notNullVerification/NotNullInstrumenterClassVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/NotNullInstrumenterClassVisitor.java
@@ -67,6 +67,7 @@ public class NotNullInstrumenterClassVisitor extends ClassVisitor {
 
     @Override
     public void visitInnerClass(final String name, final String outer, final String innerName, final int access) {
+        super.visitInnerClass(name, outer, innerName, access);
         if (name.equals(className)) {
             isAnonymous = innerName == null;
         }

--- a/src/test/data/se/eris/test/TestNotNull.java
+++ b/src/test/data/se/eris/test/TestNotNull.java
@@ -63,4 +63,8 @@ public class TestNotNull {
         @Override
         public void overload(@NotNull Subarg s) {}
     }
+    
+    public static class InnerClassesSegmentIsPreserved {
+        public static class ASub {}
+    }
 }

--- a/src/test/data/se/eris/test/TestNotNull.java
+++ b/src/test/data/se/eris/test/TestNotNull.java
@@ -52,4 +52,15 @@ public class TestNotNull {
         private String s = "synthetic";
     }
 
+    public static class Superarg {}
+    public static class Subarg extends Superarg {}
+
+    public static class Super<S extends Superarg> {
+        public void overload(@NotNull S s) {}
+    }
+
+    public static class Sub extends Super<Subarg> {
+        @Override
+        public void overload(@NotNull Subarg s) {}
+    }
 }

--- a/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
@@ -17,10 +17,15 @@ package se.eris.notnull;
 
 import com.intellij.NotNullInstrumenter;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import se.eris.maven.NopLogWrapper;
 import se.eris.notnull.instrumentation.ClassMatcher;
 import se.eris.util.ReflectionUtil;
@@ -28,13 +33,12 @@ import se.eris.util.ReflectionUtil;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import java.io.File;
+import java.io.FileInputStream;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,9 +51,12 @@ public class AnnotationNotNullInstrumenterTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
+    private static URLClassLoader classLoader;
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void beforeClass() throws MalformedURLException {
+        final URL[] classpath = {TARGET_DIR.toURI().toURL()};
+        classLoader = new URLClassLoader(classpath);
         final String fileToCompile = getSrcFile(SRC_DIR, "se/eris/test/TestNotNull.java");
         compile(fileToCompile);
 
@@ -70,7 +77,7 @@ public class AnnotationNotNullInstrumenterTest {
 
     @Test
     public void annotatedParameter_shouldValidate() throws Exception {
-        final Class<?> c = getCompiledClass(TARGET_DIR, "se.eris.test.TestNotNull");
+        final Class<?> c = getCompiledClass("se.eris.test.TestNotNull");
         final Method notNullParameterMethod = c.getMethod("notNullParameter", String.class);
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, "should work");
 
@@ -81,7 +88,7 @@ public class AnnotationNotNullInstrumenterTest {
 
     @Test
     public void notnullReturn_shouldValidate() throws Exception {
-        final Class<?> c = getCompiledClass(TARGET_DIR, "se.eris.test.TestNotNull");
+        final Class<?> c = getCompiledClass("se.eris.test.TestNotNull");
         final Method notNullReturnMethod = c.getMethod("notNullReturn", String.class);
         ReflectionUtil.simulateMethodCall(notNullReturnMethod, "should work");
 
@@ -92,7 +99,7 @@ public class AnnotationNotNullInstrumenterTest {
 
     @Test
     public void annotatedReturn_shouldValidate() throws Exception {
-        final Class<?> c = getCompiledClass(TARGET_DIR, "se.eris.test.TestNotNull");
+        final Class<?> c = getCompiledClass("se.eris.test.TestNotNull");
         final Method notNullReturnMethod = c.getMethod("annotatedReturn", String.class);
         ReflectionUtil.simulateMethodCall(notNullReturnMethod, "should work");
 
@@ -101,10 +108,69 @@ public class AnnotationNotNullInstrumenterTest {
         ReflectionUtil.simulateMethodCall(notNullReturnMethod, new Object[]{null});
     }
 
+    @Test
+    public void overridingMethod_isInstrumented() throws Exception {
+        final Class<?> subargClass = getCompiledClass("se.eris.test.TestNotNull$Subarg");
+        final Class<?> subClass = getCompiledClass("se.eris.test.TestNotNull$Sub");
+        final Method specializedMethod = subClass.getMethod("overload", subargClass);
+        Assert.assertFalse(specializedMethod.isSynthetic());
+        Assert.assertFalse(specializedMethod.isBridge());
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Argument 0 for @NotNull parameter of se/eris/test/TestNotNull$Sub.overload must not be null");
+        ReflectionUtil.simulateMethodCall(subClass.newInstance(), specializedMethod, new Object[]{null});
+    }
+
+    @Test
+    public void syntheticMethod_dispatchesToSpecializedMethod() throws Exception {
+        final Class<?> superargClass = getCompiledClass("se.eris.test.TestNotNull$Superarg");
+        final Class<?> subClass = getCompiledClass("se.eris.test.TestNotNull$Sub");
+        final Method generalMethod = subClass.getMethod("overload", superargClass);
+        Assert.assertTrue(generalMethod.isSynthetic());
+        Assert.assertTrue(generalMethod.isBridge());
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage("Argument 0 for @NotNull parameter of se/eris/test/TestNotNull$Sub.overload must not be null");
+        ReflectionUtil.simulateMethodCall(subClass.newInstance(), generalMethod, new Object[]{null});
+    }
+
+    @Test
+    public void onlySpecificMethod_isInstrumented() throws Exception {
+        // Check that only the specific method has a string annotation indicating instrumentation
+        final File f = new File(TARGET_DIR, "se/eris/test/TestNotNull$Sub.class");
+        Assert.assertTrue(f.isFile());
+        final ClassReader cr = new ClassReader(new FileInputStream(f));
+        final ArrayList<String> strings = getStringConstants(cr, "overload");
+        final String onlyExpectedString = "(Lse/eris/test/TestNotNull$Subarg;)V:" +
+                "Argument 0 for @NotNull parameter of " +
+                "se/eris/test/TestNotNull$Sub.overload must not be null";
+        Assert.assertEquals(Collections.singletonList(
+                onlyExpectedString), strings);
+    }
+
     @NotNull
-    private Class<?> getCompiledClass(@NotNull final File targetDir, @NotNull final String className) throws MalformedURLException, ClassNotFoundException {
-        final URL[] classpath = {targetDir.toURI().toURL()};
-        final URLClassLoader classLoader = new URLClassLoader(classpath);
+    private ArrayList<String> getStringConstants(ClassReader cr, final String methodName) {
+        final ArrayList<String> strings = new ArrayList<>();
+        cr.accept(new ClassVisitor(Opcodes.ASM5) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, final String desc, String signature,
+                                             String[] exceptions) {
+                if (name.equals(methodName)) {
+                    return new MethodVisitor(Opcodes.ASM5) {
+                        @Override
+                        public void visitLdcInsn(Object cst) {
+                            if (cst instanceof String) {
+                                strings.add(desc + ":" + cst);
+                            }
+                        }
+                    };
+                }
+                return super.visitMethod(access, name, desc, signature, exceptions);
+            }
+        }, 0);
+        return strings;
+    }
+
+    @NotNull
+    private Class<?> getCompiledClass(@NotNull final String className) throws MalformedURLException, ClassNotFoundException {
         return classLoader.loadClass(className);
     }
 

--- a/src/test/java/se/eris/notnull/InnerClass.java
+++ b/src/test/java/se/eris/notnull/InnerClass.java
@@ -1,0 +1,47 @@
+package se.eris.notnull;
+
+class InnerClass {
+    public String name;
+    public String outerName;
+    public String innerName;
+    int access;
+
+    public InnerClass(String name, String outerName, String innerName, int access) {
+        this.name = name;
+        this.outerName = outerName;
+        this.innerName = innerName;
+        this.access = access;
+    }
+
+    @Override
+    public String toString() {
+        return "InnerClass{" +
+                "name='" + name + '\'' +
+                ", outerName='" + outerName + '\'' +
+                ", innerName='" + innerName + '\'' +
+                ", access=" + access +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        InnerClass that = (InnerClass) o;
+
+        if (access != that.access) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (outerName != null ? !outerName.equals(that.outerName) : that.outerName != null) return false;
+        return innerName != null ? innerName.equals(that.innerName) : that.innerName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (outerName != null ? outerName.hashCode() : 0);
+        result = 31 * result + (innerName != null ? innerName.hashCode() : 0);
+        result = 31 * result + access;
+        return result;
+    }
+}

--- a/src/test/java/se/eris/util/ReflectionUtil.java
+++ b/src/test/java/se/eris/util/ReflectionUtil.java
@@ -31,9 +31,9 @@ public class ReflectionUtil {
         return simulateMethodCall(null, method, params);
     }
 
-    public static Object simulateMethodCall(@Nullable final Class<?> cls, @NotNull final Method method, @NotNull final Object... params) throws IllegalAccessException, InvocationTargetException {
+    public static Object simulateMethodCall(@Nullable final Object o, @NotNull final Method method, @NotNull final Object... params) throws IllegalAccessException, InvocationTargetException {
         try {
-            return method.invoke(cls, params);
+            return method.invoke(o, params);
         } catch (final InvocationTargetException e) {
             final Throwable cause = e.getCause();
             if (cause instanceof RuntimeException) {


### PR DESCRIPTION
I removed instrumentation for synthetic methods in the general case. This basically entailed moving the synthetic checks to `ThrowOnNullMethodVisitor`.

Added test data. Refactored the test to use the same classloader, otherwise the clazz.getMethod(...) didn't really work as expected. Added a way of checking if a method has been instrumented by checking the its constants for validation messages.