### PR TITLE
Include parameter name in exception message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.eris</groupId>
     <artifactId>notnull-instrumenter-maven-plugin</artifactId>
-    <version>0.6.6</version>
+    <version>0.6.7-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <description>NotNull annotations instrumenter maven plugin</description>

--- a/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
@@ -67,10 +67,8 @@ class AnnotationThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
 
     @Override
     @NotNull
-    protected String getThrowMessage(int notNullParam) {
-        int pnum = getSourceCodeParameterNumber(notNullParam);
-        String pname = parameterNames == null || parameterNames.size() <= pnum? "" : " '" + parameterNames.get(pnum) + "'";
-        return "Argument " + pnum + " for @NotNull parameter" + pname + " of " + className + "." + methodName + " must not be null";
+    protected String notNullCause() {
+        return "@NotNull";
     }
 
     /**

--- a/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
@@ -69,7 +69,7 @@ class AnnotationThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
     @NotNull
     protected String getThrowMessage(int notNullParam) {
         int pnum = getSourceCodeParameterNumber(notNullParam);
-        String pname = parameterNames == null ? "" : " '" + parameterNames.get(pnum) + "'";
+        String pname = parameterNames == null || parameterNames.size() <= pnum? "" : " '" + parameterNames.get(pnum) + "'";
         return "Argument " + pnum + " for @NotNull parameter" + pname + " of " + className + "." + methodName + " must not be null";
     }
 

--- a/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
@@ -68,7 +68,9 @@ class AnnotationThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
     @Override
     @NotNull
     protected String getThrowMessage(int notNullParam) {
-        return "Argument " + getSourceCodeParameterNumber(notNullParam) + " for @NotNull parameter of " + className + "." + methodName + " must not be null";
+        int pnum = getSourceCodeParameterNumber(notNullParam);
+        String pname = parameterNames == null ? "" : " '" + parameterNames.get(pnum) + "'";
+        return "Argument " + pnum + " for @NotNull parameter" + pname + " of " + className + "." + methodName + " must not be null";
     }
 
     /**

--- a/src/main/java/com/intellij/compiler/notNullVerification/ImplicitThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ImplicitThrowOnNullMethodVisitor.java
@@ -89,8 +89,8 @@ class ImplicitThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
 
     @Override
     @NotNull
-    protected String getThrowMessage(final int parameterNumber) {
-        return "Argument " + getSourceCodeParameterNumber(parameterNumber) + " for implicit 'NotNull' parameter of " + className + "." + methodName + " must not be null";
+    protected String notNullCause() {
+        return "implicit NotNull";
     }
 
     /**

--- a/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
@@ -68,7 +68,9 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
     /** This will be invoked only when visiting bytecode produced by java 8+ compiler with '-parameters' option. */
     @Override
     public void visitParameter(String name, int access) {
-        if (parameterNames == null) parameterNames = new ArrayList<>(argumentTypes.length);
+        if (parameterNames == null) {
+            parameterNames = new ArrayList<>(argumentTypes.length);
+        }
         parameterNames.add(name);
         if (mv != null) mv.visitParameter(name, access);
     }

--- a/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
@@ -172,7 +172,19 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
     }
 
     @NotNull
-    protected abstract String getThrowMessage(int parameterNumber);
+    private String getThrowMessage(int parameterNumber) {
+        int pnum = getSourceCodeParameterNumber(parameterNumber);
+        String pname = parameterNames == null || parameterNames.size() <= pnum
+            ? "" : String.format(" '%s'", parameterNames.get(pnum));
+        return String.format(
+            "Argument %d for %s parameter%s of %s.%s must not be null",
+            pnum, notNullCause(), pname, className, methodName
+        );
+    }
+
+    /** Returns the reason for the parameter to be instrumented as non-null one. */
+    @NotNull
+    protected abstract String notNullCause();
 
     int increaseSyntheticCount() {
         return syntheticCount++;

--- a/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
@@ -35,6 +35,7 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
     private static final String ISE_CLASS_NAME = "java/lang/IllegalStateException";
     private static final String CONSTRUCTOR_NAME = "<init>";
 
+    protected ArrayList<String> parameterNames = null;
     final Type[] argumentTypes;
     private final Type returnType;
     boolean isReturnNotNull;
@@ -62,6 +63,14 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
 
     private void setInstrumented() {
         instrumented = true;
+    }
+
+    /** This will be invoked only when visiting bytecode produced by java 8+ compiler with '-parameters' option. */
+    @Override
+    public void visitParameter(String name, int access) {
+        if (parameterNames == null) parameterNames = new ArrayList<>(argumentTypes.length);
+        parameterNames.add(name);
+        if (mv != null) mv.visitParameter(name, access);
     }
 
     /**

--- a/src/main/java/se/eris/asm/ClassInfo.java
+++ b/src/main/java/se/eris/asm/ClassInfo.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
 * Collects class info. That is name, modifiers, super class, and interfaces.
@@ -32,14 +33,14 @@ public class ClassInfo {
     private final int access;
     @NotNull
     private final String name;
-    @NotNull
+    @Nullable
     private final String signature;
     @Nullable
     private final String superName;
     @NotNull
     private final String[] interfaces;
 
-    public ClassInfo(final int version, final int access, @NotNull final String name, @NotNull final String signature, @Nullable final String superName, @Nullable final String[] interfaces) {
+    public ClassInfo(final int version, final int access, @NotNull final String name, @Nullable final String signature, @Nullable final String superName, @Nullable final String[] interfaces) {
         this.version = version;
         this.access = access;
         this.name = name;
@@ -61,7 +62,7 @@ public class ClassInfo {
         return name;
     }
 
-    @NotNull
+    @Nullable
     public String getSignature() {
         return signature;
     }
@@ -90,7 +91,7 @@ public class ClassInfo {
         if (version != classInfo.version) return false;
         if (access != classInfo.access) return false;
         if (!name.equals(classInfo.name)) return false;
-        if (!signature.equals(classInfo.signature)) return false;
+        if (!Objects.equals(signature, classInfo.signature)) return false;
         if (superName != null ? !superName.equals(classInfo.superName) : classInfo.superName != null) return false;
         // Probably incorrect - comparing Object[] arrays with Arrays.equals
         return Arrays.equals(interfaces, classInfo.interfaces);
@@ -102,7 +103,7 @@ public class ClassInfo {
         int result = version;
         result = 31 * result + access;
         result = 31 * result + name.hashCode();
-        result = 31 * result + signature.hashCode();
+        result = 31 * result + (signature == null ? 0 : signature.hashCode());
         result = 31 * result + (superName != null ? superName.hashCode() : 0);
         result = 31 * result + Arrays.hashCode(interfaces);
         return result;

--- a/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
@@ -45,7 +45,7 @@ import java.util.Set;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertTrue;
 
 public class AnnotationNotNullInstrumenterTest {
@@ -87,7 +87,10 @@ public class AnnotationNotNullInstrumenterTest {
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, "should work");
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for @NotNull parameter of se/eris/test/TestNotNull.notNullParameter must not be null");
+        exception.expectMessage(allOf(
+                startsWith("Argument 0 for @NotNull parameter "),
+                endsWith(" of se/eris/test/TestNotNull.notNullParameter must not be null")
+        ));
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, new Object[]{null});
     }
 
@@ -121,7 +124,10 @@ public class AnnotationNotNullInstrumenterTest {
         assertFalse(specializedMethod.isSynthetic());
         assertFalse(specializedMethod.isBridge());
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for @NotNull parameter of se/eris/test/TestNotNull$Sub.overload must not be null");
+        exception.expectMessage(allOf(
+                startsWith("Argument 0 for @NotNull parameter "),
+                endsWith(" of se/eris/test/TestNotNull$Sub.overload must not be null")
+        ));
         ReflectionUtil.simulateMethodCall(subClass.newInstance(), specializedMethod, new Object[]{null});
     }
 
@@ -133,7 +139,10 @@ public class AnnotationNotNullInstrumenterTest {
         assertTrue(generalMethod.isSynthetic());
         assertTrue(generalMethod.isBridge());
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for @NotNull parameter of se/eris/test/TestNotNull$Sub.overload must not be null");
+        exception.expectMessage(allOf(
+                startsWith("Argument 0 for @NotNull parameter "),
+                endsWith(" of se/eris/test/TestNotNull$Sub.overload must not be null")
+        ));
         ReflectionUtil.simulateMethodCall(subClass.newInstance(), generalMethod, new Object[]{null});
     }
 
@@ -144,11 +153,13 @@ public class AnnotationNotNullInstrumenterTest {
         assertTrue(f.isFile());
         final ClassReader cr = new ClassReader(new FileInputStream(f));
         final List<String> strings = getStringConstants(cr, "overload");
-        final String onlyExpectedString = "(Lse/eris/test/TestNotNull$Subarg;)V:" +
-                "Argument 0 for @NotNull parameter of " +
-                "se/eris/test/TestNotNull$Sub.overload must not be null";
-        assertEquals(Collections.singletonList(
-                onlyExpectedString), strings);
+        assertEquals(1, strings.size());
+        for (String string : strings) {
+            assertThat(string, allOf(
+                    startsWith("(Lse/eris/test/TestNotNull$Subarg;)V:Argument 0 for @NotNull parameter "),
+                    endsWith(" of se/eris/test/TestNotNull$Sub.overload must not be null")
+            ));
+        }
     }
 
     @Test

--- a/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
@@ -45,7 +45,8 @@ import java.util.Set;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
 public class AnnotationNotNullInstrumenterTest {

--- a/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/AnnotationNotNullInstrumenterTest.java
@@ -60,6 +60,12 @@ public class AnnotationNotNullInstrumenterTest {
 
     private static TestCompiler compiler;
 
+    /** Returns single-quoted parameter name if compiler supports `-parameters` option, empty string otherwise. */
+    @NotNull
+    private static String maybeName(@NotNull String parameterName) {
+        return compiler.parametersOptionSupported() ? String.format(" '%s'", parameterName) : "";
+    }
+
     @BeforeClass
     public static void beforeClass() throws MalformedURLException {
         compiler = TestCompiler.create(CLASSES_DIRECTORY);
@@ -87,9 +93,9 @@ public class AnnotationNotNullInstrumenterTest {
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, "should work");
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(allOf(
-                startsWith("Argument 0 for @NotNull parameter "),
-                endsWith(" of se/eris/test/TestNotNull.notNullParameter must not be null")
+        exception.expectMessage(is(
+            "Argument 0 for @NotNull parameter" + maybeName("s") +
+                " of se/eris/test/TestNotNull.notNullParameter must not be null"
         ));
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, new Object[]{null});
     }
@@ -124,9 +130,9 @@ public class AnnotationNotNullInstrumenterTest {
         assertFalse(specializedMethod.isSynthetic());
         assertFalse(specializedMethod.isBridge());
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(allOf(
-                startsWith("Argument 0 for @NotNull parameter "),
-                endsWith(" of se/eris/test/TestNotNull$Sub.overload must not be null")
+        exception.expectMessage(is(
+            "Argument 0 for @NotNull parameter" + maybeName("s") +
+                " of se/eris/test/TestNotNull$Sub.overload must not be null"
         ));
         ReflectionUtil.simulateMethodCall(subClass.newInstance(), specializedMethod, new Object[]{null});
     }
@@ -139,9 +145,9 @@ public class AnnotationNotNullInstrumenterTest {
         assertTrue(generalMethod.isSynthetic());
         assertTrue(generalMethod.isBridge());
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(allOf(
-                startsWith("Argument 0 for @NotNull parameter "),
-                endsWith(" of se/eris/test/TestNotNull$Sub.overload must not be null")
+        exception.expectMessage(is(
+            "Argument 0 for @NotNull parameter" + maybeName("s") +
+                " of se/eris/test/TestNotNull$Sub.overload must not be null"
         ));
         ReflectionUtil.simulateMethodCall(subClass.newInstance(), generalMethod, new Object[]{null});
     }
@@ -155,9 +161,9 @@ public class AnnotationNotNullInstrumenterTest {
         final List<String> strings = getStringConstants(cr, "overload");
         assertEquals(1, strings.size());
         for (String string : strings) {
-            assertThat(string, allOf(
-                    startsWith("(Lse/eris/test/TestNotNull$Subarg;)V:Argument 0 for @NotNull parameter "),
-                    endsWith(" of se/eris/test/TestNotNull$Sub.overload must not be null")
+            assertThat(string, is(
+                "(Lse/eris/test/TestNotNull$Subarg;)V:Argument 0 for @NotNull parameter" + maybeName("s") +
+                    " of se/eris/test/TestNotNull$Sub.overload must not be null"
             ));
         }
     }

--- a/src/test/java/se/eris/notnull/ExcludeClassesNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/ExcludeClassesNotNullInstrumenterTest.java
@@ -16,6 +16,7 @@
 package se.eris.notnull;
 
 import com.intellij.NotNullInstrumenter;
+import org.jetbrains.annotations.NotNull;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +34,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Tests to verify that package exclusion works.
@@ -50,6 +52,12 @@ public class ExcludeClassesNotNullInstrumenterTest {
     public ExpectedException exception = ExpectedException.none();
 
     private static TestCompiler compiler;
+
+    /** Returns single-quoted parameter name if compiler supports `-parameters` option, empty string otherwise. */
+    @NotNull
+    private static String maybeName(@NotNull String parameterName) {
+        return compiler.parametersOptionSupported() ? String.format(" '%s'", parameterName) : "";
+    }
 
     @BeforeClass
     public static void beforeClass() throws MalformedURLException {
@@ -70,9 +78,9 @@ public class ExcludeClassesNotNullInstrumenterTest {
         final Method notNullParameterMethod = c.getMethod("notNullParameter", String.class);
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(allOf(
-                startsWith("Argument 0 for @NotNull parameter "),
-                endsWith(" of se/eris/exclude/" + TEST_CLASS + ".notNullParameter must not be null")
+        exception.expectMessage(is(
+            "Argument 0 for @NotNull parameter" + maybeName("s") +
+                " of se/eris/exclude/" + TEST_CLASS + ".notNullParameter must not be null"
         ));
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, new Object[]{null});
     }

--- a/src/test/java/se/eris/notnull/ExcludeClassesNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/ExcludeClassesNotNullInstrumenterTest.java
@@ -33,7 +33,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.*;
 
 /**
  * Tests to verify that package exclusion works.
@@ -70,7 +70,10 @@ public class ExcludeClassesNotNullInstrumenterTest {
         final Method notNullParameterMethod = c.getMethod("notNullParameter", String.class);
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for @NotNull parameter of se/eris/exclude/" + TEST_CLASS + ".notNullParameter must not be null");
+        exception.expectMessage(allOf(
+                startsWith("Argument 0 for @NotNull parameter "),
+                endsWith(" of se/eris/exclude/" + TEST_CLASS + ".notNullParameter must not be null")
+        ));
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, new Object[]{null});
     }
 

--- a/src/test/java/se/eris/notnull/ImplicitClassNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/ImplicitClassNotNullInstrumenterTest.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 
 public class ImplicitClassNotNullInstrumenterTest {
 
@@ -52,6 +53,12 @@ public class ImplicitClassNotNullInstrumenterTest {
     public ExpectedException exception = ExpectedException.none();
 
     private static TestCompiler compiler;
+
+    /** Returns single-quoted parameter name if compiler supports `-parameters` option, empty string otherwise. */
+    @NotNull
+    private static String maybeName(@NotNull String parameterName) {
+        return compiler.parametersOptionSupported() ? String.format(" '%s'", parameterName) : "";
+    }
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -98,7 +105,9 @@ public class ImplicitClassNotNullInstrumenterTest {
         final Method implicitParameterMethod = c.getMethod("implicitParameter", String.class);
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for implicit 'NotNull' parameter of se/eris/implicit/" + CLASS_NAME + ".implicitParameter must not be null");
+        exception.expectMessage(is(
+            "Argument 0 for implicit NotNull parameter" + maybeName("s") + " of se/eris/implicit/" + CLASS_NAME + ".implicitParameter must not be null"
+        ));
         ReflectionUtil.simulateMethodCall(implicitParameterMethod, new Object[]{null});
     }
 
@@ -108,7 +117,9 @@ public class ImplicitClassNotNullInstrumenterTest {
         final Constructor<?> implicitParameterConstructor = c.getConstructor(String.class);
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for implicit 'NotNull' parameter of se/eris/implicit/" + CLASS_NAME + ".<init> must not be null");
+        exception.expectMessage(is(
+            "Argument 0 for implicit NotNull parameter" + maybeName("s") + " of se/eris/implicit/" + CLASS_NAME + ".<init> must not be null"
+        ));
         ReflectionUtil.simulateConstructorCall(implicitParameterConstructor, new Object[]{null});
     }
 

--- a/src/test/java/se/eris/notnull/ImplicitInnerClassNullableInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/ImplicitInnerClassNullableInstrumenterTest.java
@@ -16,6 +16,7 @@
 package se.eris.notnull;
 
 import com.intellij.NotNullInstrumenter;
+import org.jetbrains.annotations.NotNull;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 
 public class ImplicitInnerClassNullableInstrumenterTest {
 
@@ -49,6 +51,12 @@ public class ImplicitInnerClassNullableInstrumenterTest {
     public ExpectedException exception = ExpectedException.none();
 
     private static TestCompiler compiler;
+
+    /** Returns single-quoted parameter name if compiler supports `-parameters` option, empty string otherwise. */
+    @NotNull
+    private static String maybeName(@NotNull String parameterName) {
+        return compiler.parametersOptionSupported() ? String.format(" '%s'", parameterName) : "";
+    }
 
     @BeforeClass
     public static void beforeClass() throws MalformedURLException {
@@ -72,7 +80,9 @@ public class ImplicitInnerClassNullableInstrumenterTest {
         ReflectionUtil.simulateMethodCall(anonymousClassNullable);
 
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for implicit 'NotNull' parameter of se/eris/implicit/" + CLASS_NAME + "$Foo.<init> must not be null");
+        exception.expectMessage(is(
+            "Argument 0 for implicit NotNull parameter" + maybeName("i") + " of se/eris/implicit/" + CLASS_NAME + "$Foo.<init> must not be null"
+        ));
         final Method anonymousClassNotNull = c.getMethod("anonymousClassNotNull");
         ReflectionUtil.simulateMethodCall(anonymousClassNotNull);
     }

--- a/src/test/java/se/eris/notnull/ImplicitNotNullInstrumenterTest.java
+++ b/src/test/java/se/eris/notnull/ImplicitNotNullInstrumenterTest.java
@@ -54,6 +54,12 @@ public class ImplicitNotNullInstrumenterTest {
 
     private static TestCompiler compiler;
 
+    /** Returns single-quoted parameter name if compiler supports `-parameters` option, empty string otherwise. */
+    @NotNull
+    private static String maybeName(@NotNull String parameterName) {
+        return compiler.parametersOptionSupported() ? String.format(" '%s'", parameterName) : "";
+    }
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         compiler = TestCompiler.create(CLASSES_DIRECTORY);
@@ -80,7 +86,9 @@ public class ImplicitNotNullInstrumenterTest {
         final Method notNullParameterMethod = c.getMethod("notNullParameter", String.class);
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, "should work");
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for implicit 'NotNull' parameter of se/eris/test/" + CLASS_NAME + ".notNullParameter must not be null");
+        exception.expectMessage(is(
+            "Argument 0 for implicit NotNull parameter" + maybeName("s") + " of se/eris/test/" + CLASS_NAME + ".notNullParameter must not be null"
+        ));
         ReflectionUtil.simulateMethodCall(notNullParameterMethod, new Object[]{null});
     }
 
@@ -89,7 +97,9 @@ public class ImplicitNotNullInstrumenterTest {
         final Class<?> c = compiler.getCompiledClass(TEST_CLASS);
         final Method implicitParameterMethod = c.getMethod("implicitParameter", String.class);
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Argument 0 for implicit 'NotNull' parameter of se/eris/test/" + CLASS_NAME + ".implicitParameter must not be null");
+        exception.expectMessage(is(
+            "Argument 0 for implicit NotNull parameter" + maybeName("s") + " of se/eris/test/" + CLASS_NAME + ".implicitParameter must not be null"
+        ));
         ReflectionUtil.simulateMethodCall(implicitParameterMethod, new Object[]{null});
     }
 

--- a/src/test/java/se/eris/util/TestCompiler.java
+++ b/src/test/java/se/eris/util/TestCompiler.java
@@ -13,7 +13,9 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class TestCompiler {
 
@@ -33,8 +35,12 @@ public class TestCompiler {
 
     public boolean compile(@NotNull final File...filesToCompile) {
             final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+            List<String> options = new ArrayList<>();
+            options.addAll(Arrays.asList(getOutputPathParameter(targetDir)));
+            // http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html#options
+            if (compiler.isSupportedOption("-parameters") != -1) options.add("-parameters");
             final Iterable<? extends JavaFileObject> javaFileObjects = getJavaFileObjects(compiler, filesToCompile);
-            final JavaCompiler.CompilationTask task = compiler.getTask(null, null, null, Arrays.asList(getOutputPathParameter(targetDir)), null, javaFileObjects);
+            final JavaCompiler.CompilationTask task = compiler.getTask(null, null, null, options, null, javaFileObjects);
             return task.call();
         }
 

--- a/src/test/java/se/eris/util/TestCompiler.java
+++ b/src/test/java/se/eris/util/TestCompiler.java
@@ -49,7 +49,9 @@ public class TestCompiler {
         List<String> options = new ArrayList<>();
         options.add("-d");
         options.add(targetDir.toString());
-        if (parametersOptionSupported) options.add("-parameters");
+        if (parametersOptionSupported) {
+            options.add("-parameters");
+        }
         return options;
     }
 


### PR DESCRIPTION
Some coworkers of mine ~prefer~ demand to have parameter names reported in the thrown `IllegalArgumentException` message (in addition to numeric index). That helps to track things over time.

It's fairly easy to do for bytecode compiled with `-parameters` option (javac 8+). This patch adds this capability.
The message would look similar to the ones generated by this plugin and IntelliJ compiler's native instrumentation, e.g.:
> `Argument 0 for @NotNull parameter 's' of se/eris/test/TestNotNull.notNullParameter must not be null`

Ideally, the method signature (with parameter types) could be included in the message - this would help to disambiguate overloaded methods (given that the exception stack trace doesn't include instrumented bytecode line numbers) - but that would be something for another patch.