### PR TITLE
feature/warn-instead-of-throw

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>se.eris</groupId>
     <artifactId>notnull-instrumenter-maven-plugin</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0-warn-instead-of-throw-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <description>NotNull annotations instrumenter maven plugin</description>
@@ -120,7 +120,6 @@
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/src/main/java/com/intellij/AbstractNotNullInstrumenterTask.java
+++ b/src/main/java/com/intellij/AbstractNotNullInstrumenterTask.java
@@ -56,6 +56,10 @@ abstract class AbstractNotNullInstrumenterTask extends AbstractMojo {
 
     @Parameter
     private boolean implicit;
+
+    @Parameter
+    private boolean warnInsteadOfThrow;
+
     @Parameter(property = "se.eris.notnull.instrument", defaultValue = "true")
     private boolean instrument;
 
@@ -98,6 +102,7 @@ abstract class AbstractNotNullInstrumenterTask extends AbstractMojo {
 
     private Configuration getConfiguration() {
         return new Configuration(implicit,
+                warnInsteadOfThrow,
                 getAnnotationConfiguration(nullToEmpty(notNull), nullToEmpty(nullable)),
                 getExcludeConfiguration(nullToEmpty(excludes)));
     }

--- a/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/AnnotationThrowOnNullMethodVisitor.java
@@ -30,8 +30,8 @@ class AnnotationThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
 
     private final Set<String> notNullAnnotations;
 
-    AnnotationThrowOnNullMethodVisitor(@Nullable final MethodVisitor methodVisitor, @NotNull final Type[] argumentTypes, @NotNull final Type returnType, final int access, @NotNull final String methodName, @NotNull final ClassInfo classInfo, @NotNull final Set<String> notNullAnnotations, final Boolean isAnonymous) {
-        super(AsmUtils.ASM_OPCODES_VERSION, methodVisitor, argumentTypes, returnType, access, methodName, classInfo, false, isAnonymous);
+    AnnotationThrowOnNullMethodVisitor(@Nullable final MethodVisitor methodVisitor, @NotNull final Type[] argumentTypes, @NotNull final Type returnType, final int access, @NotNull final String methodName, @NotNull final ClassInfo classInfo, @NotNull final Set<String> notNullAnnotations, final Boolean isAnonymous, final boolean warnInsteadOfThrow) {
+        super(AsmUtils.ASM_OPCODES_VERSION, methodVisitor, argumentTypes, returnType, access, methodName, classInfo, false, isAnonymous, warnInsteadOfThrow);
         this.notNullAnnotations = notNullAnnotations;
     }
 

--- a/src/main/java/com/intellij/compiler/notNullVerification/ImplicitThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ImplicitThrowOnNullMethodVisitor.java
@@ -30,8 +30,8 @@ class ImplicitThrowOnNullMethodVisitor extends ThrowOnNullMethodVisitor {
 
     private final Set<String> nullableAnnotations;
 
-    ImplicitThrowOnNullMethodVisitor(@Nullable final MethodVisitor methodVisitor, @NotNull final Type[] argumentTypes, @NotNull final Type returnType, final int access, @NotNull final String methodName, @NotNull final ClassInfo classInfo, @NotNull final Set<String> nullableAnnotations, @Nullable final Boolean isAnonymousClass) {
-        super(AsmUtils.ASM_OPCODES_VERSION, methodVisitor, argumentTypes, returnType, access, methodName, classInfo, true, isAnonymousClass);
+    ImplicitThrowOnNullMethodVisitor(@Nullable final MethodVisitor methodVisitor, @NotNull final Type[] argumentTypes, @NotNull final Type returnType, final int access, @NotNull final String methodName, @NotNull final ClassInfo classInfo, @NotNull final Set<String> nullableAnnotations, @Nullable final Boolean isAnonymousClass, final boolean warnInsteadOfThrow) {
+        super(AsmUtils.ASM_OPCODES_VERSION, methodVisitor, argumentTypes, returnType, access, methodName, classInfo, true, isAnonymousClass, warnInsteadOfThrow);
         this.nullableAnnotations = nullableAnnotations;
         addImplicitNotNulls();
     }

--- a/src/main/java/com/intellij/compiler/notNullVerification/NotNullInstrumenterClassVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/NotNullInstrumenterClassVisitor.java
@@ -89,9 +89,9 @@ public class NotNullInstrumenterClassVisitor extends ClassVisitor {
         final MethodVisitor methodVisitor = cv.visitMethod(access, name, desc, signature, exceptions);
         final ThrowOnNullMethodVisitor visitor;
         if (classAnnotatedImplicit || configuration.isImplicitInstrumentation(toClassName(classInfo.getName()))) {
-            visitor = new ImplicitThrowOnNullMethodVisitor(methodVisitor, argumentTypes, returnType, access, name, classInfo, nullable, isAnonymous);
+            visitor = new ImplicitThrowOnNullMethodVisitor(methodVisitor, argumentTypes, returnType, access, name, classInfo, nullable, isAnonymous, configuration.isWarnInsteadOfThrow());
         } else {
-            visitor = new AnnotationThrowOnNullMethodVisitor(methodVisitor, argumentTypes, returnType, access, name, classInfo, notnull, isAnonymous);
+            visitor = new AnnotationThrowOnNullMethodVisitor(methodVisitor, argumentTypes, returnType, access, name, classInfo, notnull, isAnonymous, configuration.isWarnInsteadOfThrow());
         }
         methodVisitors.add(visitor);
         return visitor;

--- a/src/main/java/se/eris/notnull/Configuration.java
+++ b/src/main/java/se/eris/notnull/Configuration.java
@@ -24,6 +24,7 @@ import java.util.Set;
 public class Configuration {
 
     private final boolean implicit;
+    private final boolean warnInsteadOfThrow;
     @NotNull
     private final AnnotationConfiguration annotationConfiguration;
     @NotNull
@@ -32,9 +33,11 @@ public class Configuration {
     @SuppressWarnings("BooleanParameter")
     public Configuration(
             final boolean implicit,
+            final boolean warnInsteadOfThrow,
             @NotNull final AnnotationConfiguration annotationConfiguration,
             @NotNull final ExcludeConfiguration excludeConfiguration) {
         this.implicit = implicit;
+        this.warnInsteadOfThrow = warnInsteadOfThrow;
         if (annotationConfiguration.isAnnotationsConfigured()) {
             this.annotationConfiguration = annotationConfiguration;
         } else {
@@ -61,6 +64,10 @@ public class Configuration {
 
     public boolean isImplicit() {
         return implicit;
+    }
+
+    public boolean isWarnInsteadOfThrow() {
+        return warnInsteadOfThrow;
     }
 
     @NotNull

--- a/src/test/java/se/eris/functional/enums/EnumImplicitTest.java
+++ b/src/test/java/se/eris/functional/enums/EnumImplicitTest.java
@@ -43,6 +43,7 @@ class EnumImplicitTest {
     @BeforeAll
     static void beforeClass() {
         final Configuration configuration = new Configuration(true,
+                false,
                 new AnnotationConfiguration(),
                 new ExcludeConfiguration(Collections.emptySet()));
         compilers.putAll(VersionCompiler.compile(DESTINATION_BASEDIR, configuration, testClass.getJavaFile(SRC_DIR)));

--- a/src/test/java/se/eris/functional/exclude/ExcludeImplicitClassesTest.java
+++ b/src/test/java/se/eris/functional/exclude/ExcludeImplicitClassesTest.java
@@ -50,6 +50,7 @@ class ExcludeImplicitClassesTest {
     @BeforeAll
     static void beforeClass() {
         final Configuration configuration = new Configuration(true,
+                false,
                 new AnnotationConfiguration(),
                 new ExcludeConfiguration(Collections.singleton(ClassMatcher.namePattern("se.eris.exclude.*"))));
         compilers.putAll(VersionCompiler.compile(DESTINATION_BASEDIR, configuration, testClass.getJavaFile(SRC_DIR)));

--- a/src/test/java/se/eris/functional/implicit/ImplicitConfigurationInstrumenterTest.java
+++ b/src/test/java/se/eris/functional/implicit/ImplicitConfigurationInstrumenterTest.java
@@ -48,7 +48,7 @@ class ImplicitConfigurationInstrumenterTest {
 
     @BeforeAll
     static void beforeClass() {
-        final Configuration configuration = new Configuration(true, new AnnotationConfiguration(), new ExcludeConfiguration(Collections.emptySet()));
+        final Configuration configuration = new Configuration(true, false, new AnnotationConfiguration(), new ExcludeConfiguration(Collections.emptySet()));
         compilers.putAll(VersionCompiler.compile(DESTINATION_BASEDIR, configuration, testClass.getJavaFile(SRC_DIR)));
     }
 

--- a/src/test/java/se/eris/functional/nested/NestedAnnotatedInstrumenterTest.java
+++ b/src/test/java/se/eris/functional/nested/NestedAnnotatedInstrumenterTest.java
@@ -55,6 +55,7 @@ class NestedAnnotatedInstrumenterTest {
     @BeforeAll
     static void beforeClass() {
         final Configuration configuration = new Configuration(false,
+                false,
                 new AnnotationConfiguration(),
                 new ExcludeConfiguration(Collections.emptySet()));
         compilers.putAll(VersionCompiler.compile(DESTINATION_BASEDIR, configuration, testClass.getJavaFile(SRC_DIR)));

--- a/src/test/java/se/eris/functional/nested/NestedImplicitAnnotationInstrumenterTest.java
+++ b/src/test/java/se/eris/functional/nested/NestedImplicitAnnotationInstrumenterTest.java
@@ -46,6 +46,7 @@ class NestedImplicitAnnotationInstrumenterTest {
     @BeforeAll
     static void beforeClass() {
         final Configuration configuration = new Configuration(true,
+                false,
                 new AnnotationConfiguration(),
                 new ExcludeConfiguration(Collections.emptySet()));
         compilers.putAll(VersionCompiler.compile(DESTINATION_BASEDIR, configuration, testClass.getJavaFile(SRC_DIR)));

--- a/src/test/java/se/eris/functional/test/NotNullAnnotationInstrumenterTest.java
+++ b/src/test/java/se/eris/functional/test/NotNullAnnotationInstrumenterTest.java
@@ -49,7 +49,7 @@ class NotNullAnnotationInstrumenterTest {
 
     @BeforeAll
     static void beforeClass() {
-        final Configuration configuration = new Configuration(false, new AnnotationConfiguration(notNull(), Collections.emptySet()), new ExcludeConfiguration(Collections.emptySet()));
+        final Configuration configuration = new Configuration(false, false, new AnnotationConfiguration(notNull(), Collections.emptySet()), new ExcludeConfiguration(Collections.emptySet()));
         compilers.putAll(VersionCompiler.compile(DESTINATION_BASEDIR, configuration, testClass.getJavaFile(SRC_DIR)));
     }
 

--- a/src/test/java/se/eris/notnull/ConfigurationTest.java
+++ b/src/test/java/se/eris/notnull/ConfigurationTest.java
@@ -65,7 +65,7 @@ class ConfigurationTest {
     }
 
     private Configuration getDefaultNotNullConfiguration(final boolean implicit) {
-        return new Configuration(implicit, new AnnotationConfiguration(Collections.emptySet(), Collections.emptySet()), new ExcludeConfiguration(Collections.emptySet()));
+        return new Configuration(implicit, false, new AnnotationConfiguration(Collections.emptySet(), Collections.emptySet()), new ExcludeConfiguration(Collections.emptySet()));
     }
 
 }

--- a/src/test/java/se/eris/util/version/VersionCompiler.java
+++ b/src/test/java/se/eris/util/version/VersionCompiler.java
@@ -26,6 +26,7 @@ public class VersionCompiler {
 
     public static Map<String, TestCompiler> compile(final Path destinationBasedir, final File... javaFiles) {
         final Configuration configuration = new Configuration(false,
+                false,
                 new AnnotationConfiguration(notnull(), nullable()),
                 new ExcludeConfiguration(Collections.emptySet()));
         return compile(destinationBasedir, configuration, javaFiles);


### PR DESCRIPTION
This pull request adds a `warnInsteadOfThrow` configuration option. When set to `true` exceptions will not be thrown. Instead an SLF4J warning message will be logged.

The reasoning behind this PR is that migrating large code bases to implicit mode can be challenging. With this solution an application can be released to production environment without risk. The log messages can then be checked. If there was no log warn messages of this kind in the last two months (or similar) you could chose to start throwing instead.