### PR TITLE
Handle java.lang.Void return type in implicit mode

### DIFF
--- a/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
@@ -91,6 +91,7 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
      * <p>
      * {@inheritDoc}
      */
+    @Override
     public void visitInsn(final int opcode) {
         if (shouldInclude() && opcode == Opcodes.ARETURN && isReturnNotNull && !isReturnVoidReferenceType()) {
             mv.visitInsn(Opcodes.DUP);

--- a/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
@@ -93,7 +93,7 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
      */
     public void visitInsn(final int opcode) {
         if (shouldInclude() && opcode == Opcodes.ARETURN) {
-            if (isReturnNotNull) {
+            if (isReturnNotNull && !isReturnVoidReferenceType()) {
                 mv.visitInsn(Opcodes.DUP);
                 final Label skipLabel = new Label();
                 mv.visitJumpInsn(Opcodes.IFNONNULL, skipLabel);
@@ -175,6 +175,10 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
 
     boolean isReturnReferenceType() {
         return AsmUtils.isReferenceType(this.returnType);
+    }
+
+    boolean isReturnVoidReferenceType() {
+        return returnType.getClassName().equals(Void.class.getName());
     }
 
     boolean isParameterReferenceType(final int parameter) {

--- a/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
+++ b/src/main/java/com/intellij/compiler/notNullVerification/ThrowOnNullMethodVisitor.java
@@ -92,13 +92,11 @@ public abstract class ThrowOnNullMethodVisitor extends MethodVisitor {
      * {@inheritDoc}
      */
     public void visitInsn(final int opcode) {
-        if (shouldInclude() && opcode == Opcodes.ARETURN) {
-            if (isReturnNotNull && !isReturnVoidReferenceType()) {
-                mv.visitInsn(Opcodes.DUP);
-                final Label skipLabel = new Label();
-                mv.visitJumpInsn(Opcodes.IFNONNULL, skipLabel);
-                generateThrow(ISE_CLASS_NAME, "NotNull method " + classInfo.getName() + "." + methodName + " must not return null", skipLabel);
-            }
+        if (shouldInclude() && opcode == Opcodes.ARETURN && isReturnNotNull && !isReturnVoidReferenceType()) {
+            mv.visitInsn(Opcodes.DUP);
+            final Label skipLabel = new Label();
+            mv.visitJumpInsn(Opcodes.IFNONNULL, skipLabel);
+            generateThrow(ISE_CLASS_NAME, "NotNull method " + classInfo.getName() + "." + methodName + " must not return null", skipLabel);
         }
         mv.visitInsn(opcode);
     }

--- a/src/test/data/se/eris/implicit/TestImplicitClassAnnotation.java
+++ b/src/test/data/se/eris/implicit/TestImplicitClassAnnotation.java
@@ -16,6 +16,9 @@ public class TestImplicitClassAnnotation {
     public static void implicitParameter(final String s) {
     }
 
+    public static Void voidReferenceReturn() {
+        return null;
+    }
 
     public static void anonymousClassNullable() {
         new Foo((String) null) {}; // anonymous class - no way to annotate constructor parameters

--- a/src/test/java/se/eris/functional/implicit/ImplicitClassAnnotationInstrumenterTest.java
+++ b/src/test/java/se/eris/functional/implicit/ImplicitClassAnnotationInstrumenterTest.java
@@ -66,6 +66,13 @@ class ImplicitClassAnnotationInstrumenterTest {
     }
 
     @TestSupportedJavaVersions
+    void voidReturn_shouldNotBeInstrumented(final String javaVersion) throws Exception {
+        final Class<?> c = compilers.get(javaVersion).getCompiledClass(testClass.getName());
+        final Method voidReferenceReturnMethod = c.getMethod("voidReferenceReturn");
+        ReflectionUtil.simulateMethodCall(voidReferenceReturnMethod);
+    }
+
+    @TestSupportedJavaVersions
     void implicitConstructorParameter_shouldValidate(final String javaVersion) throws Exception {
         final Class<?> c = compilers.get(javaVersion).getCompiledClass(testClass);
         final Constructor<?> implicitParameterConstructor = c.getConstructor(String.class);


### PR DESCRIPTION
Since `null` is the only allowed return value for a method declared with `java.lang.Void` return type, it doesn't make much sense to throw an `IllegalStateException` for these in implicit mode.

Fixes #46