### PR TITLE
Add Maven Enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/osundblad/intellij-annotations-instrumenter-maven-plugin</url>
 
     <prerequisites>
-        <maven>3.0.0</maven>
+        <maven>${mvn.version}</maven>
     </prerequisites>
 
     <properties>
@@ -23,6 +23,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <source>8</source>
 
+        <mvn.version>3.0.0</mvn.version>
         <maven-core.version>3.3.9</maven-core.version>
         <maven-plugin-annotations.version>3.6.0</maven-plugin-annotations.version>
         <intellij-annotations.version>13.0</intellij-annotations.version>
@@ -183,7 +184,27 @@
                     </dependency>
                 </dependencies>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M2</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <message>Maven ${mvn.version} or later is required</message>
+                                    <version>${mvn.version}</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
The `<prerequisites>` element is deprecated and isn't checked in Maven 3 so we add the Maven Enforcer plugin as well.
(See http://maven.apache.org/pom.html#Prerequisites)

> The POM may have certain prerequisites in order to execute correctly. For example, perhaps there was a fix in Maven 2.0.3 that you need in order to deploy using sftp.
>
> In Maven 3, use Maven Enforcer Plugin's requireMavenVersion rule, or other rules to check other aspects.
>
> In Maven 2, here is where you give the prerequisites to building: if these are not met, Maven will fail the build before even starting. The only element that exists as a prerequisite in POM 4.0 is the maven element, which takes a minimum version number. It is checked with Maven 2, it is not any more in Maven 3.