### PR TITLE
Support for Java 18-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This code is based on Vlad Rassokhin's intellij-annotations-instrumenter-maven-plugin. The following
 significant additions/changes have been made:
 
-* Added Java 8 to 17 support
+* Added Java 8 to 21 support
 * Added configuration: which NotNull/Nullable annotations to instrument (default is still `@org.jetbrains.annotations.NotNull` and `@org.jetbrains.annotations.Nullable`)
 * Added basic unit and functional tests
 * Isolated Maven plugin dependencies to allow usage without Maven

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,10 @@
         <source>8</source>
 
         <maven-core.version>3.8.1</maven-core.version>
-        <maven-plugin-annotations.version>3.6.1</maven-plugin-annotations.version>
-        <intellij-annotations.version>20.1.0</intellij-annotations.version>
-        <asm.version>9.2</asm.version>
-        <junit-jupiter.version>5.8.1</junit-jupiter.version>
+        <maven-plugin-annotations.version>3.13.1</maven-plugin-annotations.version>
+        <intellij-annotations.version>24.1.0</intellij-annotations.version>
+        <asm.version>9.7</asm.version>
+        <junit-jupiter.version>5.10.3</junit-jupiter.version>
     </properties>
 
     <licenses>

--- a/src/test/java/se/eris/util/TestCompilerOptions.java
+++ b/src/test/java/se/eris/util/TestCompilerOptions.java
@@ -51,7 +51,7 @@ public class TestCompilerOptions {
     }
 
     private String validateJavaVersion(final String javaVersion, final String versionName) {
-        if (!javaVersion.matches("^1(\\.[2-9]|[01234567])$")) {
+        if (!javaVersion.matches("^(1\\.[2-9]|1[0-9]|2[0-1])$")) {
             throw new IllegalArgumentException("Unknown " + versionName + " version " + javaVersion);
         }
         return javaVersion;

--- a/src/test/java/se/eris/util/TestCompilerOptionsTest.java
+++ b/src/test/java/se/eris/util/TestCompilerOptionsTest.java
@@ -27,12 +27,16 @@ class TestCompilerOptionsTest {
         assertTrue(TestCompilerOptions.from(PATH, "15").targetHasParametersSupport());
         assertTrue(TestCompilerOptions.from(PATH, "16").targetHasParametersSupport());
         assertTrue(TestCompilerOptions.from(PATH, "17").targetHasParametersSupport());
+        assertTrue(TestCompilerOptions.from(PATH, "18").targetHasParametersSupport());
+        assertTrue(TestCompilerOptions.from(PATH, "19").targetHasParametersSupport());
+        assertTrue(TestCompilerOptions.from(PATH, "20").targetHasParametersSupport());
+        assertTrue(TestCompilerOptions.from(PATH, "21").targetHasParametersSupport());
     }
 
     @Test
     void javaVersion_unsupported() {
         assertThrows(IllegalArgumentException.class, () -> TestCompilerOptions.from(PATH, "1.1").targetHasParametersSupport());
-        assertThrows(IllegalArgumentException.class, () -> TestCompilerOptions.from(PATH, "18").targetHasParametersSupport());
+        assertThrows(IllegalArgumentException.class, () -> TestCompilerOptions.from(PATH, "22").targetHasParametersSupport());
     }
 
 }

--- a/src/test/java/se/eris/util/TestSupportedJavaVersions.java
+++ b/src/test/java/se/eris/util/TestSupportedJavaVersions.java
@@ -8,7 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 @ParameterizedTest(name = "Java target version: {arguments}")
-@ValueSource(strings = {"1.7", "1.8", "1.9", "10", "11", "12", "13", "14", "15", "16", "17"})
+@ValueSource(strings = {"1.8", "1.9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21"})
 public @interface TestSupportedJavaVersions {
 
     class SupportedVersions {


### PR DESCRIPTION
As mentioned in this open issue: https://github.com/osundblad/intellij-annotations-instrumenter-maven-plugin/issues/61
there is no support for Java 21 yet.

I updated the corresponding classes as described in build.md.
Unfortunately, I had to remove the support for Java 1.7 (see TestSupportedJavaVersions.java) since JDK21 doesn´t support this version anymore.